### PR TITLE
Implement fifo queue for reading/parsing messages

### DIFF
--- a/netflowv9.js
+++ b/netflowv9.js
@@ -841,6 +841,7 @@ function NetFlowV9(options) {
             var data = me.fifo.shift();
             var msg = data[0];
             var rinfo = data[1];
+            var startTime = new Date().getTime();
             if (me.fwd) {
                 var data = JSON.parse(msg.toString());
                 msg = new Buffer(data.buffer);
@@ -848,9 +849,11 @@ function NetFlowV9(options) {
             }
             if (rinfo.size<20) return;
             var o = me.nfPktDecode(msg,rinfo);
+            var timeMs = (new Date().getTime()) - startTime;
             if (o && o.flows.length > 0) { // If the packet does not contain flows, only templates we do not decode
                 o.rinfo = rinfo;
                 o.packet = msg;
+                o.decodeMs = timeMs;
                 if (me.cb)
                     me.cb(o);
                 else
@@ -858,6 +861,7 @@ function NetFlowV9(options) {
             } else if (o && o.templates) {
                 o.rinfo = rinfo;
                 o.packet = msg;
+                o.decodeMs = timeMs;
                 if (me.templateCb)
                     me.templateCb(o);
                 else

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "clone": "^1.0.0",
-    "debug": "^1.0.2"
+    "debug": "^1.0.2",
+    "dequeue": "^1.0.5"
   },
   "homepage": "https://github.com/delian/node-netflowv9",
   "devDependencies": {


### PR DESCRIPTION
I am finding that processing packets can take some time and leads to backpressure. It would be nice if the packets were read off of udp and pushed to a fifo queue which can parse these messages when the event loop can get to them (through the use of setImmediate).