### PR TITLE
Fix issue when type is not defined in nfTypes

### DIFF
--- a/js/nf9/nf9decode.js
+++ b/js/nf9/nf9decode.js
@@ -133,7 +133,7 @@ function nf9PktDecode(msg,rinfo) {
         while (buf.length > 3) {
             type = buf.readUInt16BE(0);
             tlen = buf.readUInt16BE(2);
-            debug('    SCOPE type: %d (%s) len: %d, plen: %d', type,nfTypes[type].name,tlen,plen);
+            debug('    SCOPE type: %d (%s) len: %d, plen: %d', type,nfTypes[type] ? nfTypes[type].name : 'unknown',tlen,plen);
             if (type>0) cr+=compileScope(type, plen, tlen);
             buf = buf.slice(4);
             plen += tlen;
@@ -144,7 +144,7 @@ function nf9PktDecode(msg,rinfo) {
         while (buf.length > 3) {
             type = buf.readUInt16BE(0);
             tlen = buf.readUInt16BE(2);
-            debug('    FIELD type: %d (%s) len: %d, plen: %d', type,nfTypes[type].name,tlen,plen);
+            debug('    FIELD type: %d (%s) len: %d, plen: %d', type,nfTypes[type] ? nfTypes[type].name : 'unknown',tlen,plen);
             if (type>0) cr+=compileStatement(type, plen, tlen);
             buf = buf.slice(4);
             plen += tlen;


### PR DESCRIPTION
One of our systems collecting netflow was throwing a regular error like this:

```
node-netflowv9/js/nf9/nf9decode.js:147
            debug('    FIELD type: %d (%s) len: %d, plen: %d', type,nfTypes[type].name,tlen,plen);
                                                                                  ^
TypeError: Cannot read property 'name' of undefined
    at readOptions (node-netflowv9/js/nf9/nf9decode.js:147:83)
    at NetFlowV9.nf9PktDecode (node-netflowv9/js/nf9/nf9decode.js:164:29)
    at NetFlowV9.nfPktDecode (node-netflowv9/netflowv9.js:33:25)
    at Immediate.NetFlowV9.fetch [as _onImmediate] (node-netflowv9/netflowv9.js:139:24)
    at runCallback (timers.js:789:20)
    at tryOnImmediate (timers.js:751:5)
    at processImmediate [as _immediateCallback] (timers.js:722:5)
```

and the attached patch resolved the problem.