### PR TITLE
Use Object.create(null) in place of o = {} to reduce IC_Miss

### DIFF
--- a/js/nf9/nf9decode.js
+++ b/js/nf9/nf9decode.js
@@ -46,7 +46,7 @@ function nf9PktDecode(msg,rinfo) {
 
     function compileTemplate(list) {
         var i, z, nf, n;
-        var f = "var o = {}; var t;\n";
+        var f = "var o = Object.create(null); var t;\n";
         for (i = 0, n = 0; i < list.length; i++, n += z.len) {
             z = list[i];
             nf = nfTypes[z.type];


### PR DESCRIPTION
This is an optimization from my colleague Tom, would be great to also get this merged, thanks!

Using the object literal syntax `var o = {}` and then immediately setting various properties on it such as `o['src_addr'] = ...`, can cause prototype transitions to occur frequently. As a result, it may be easier on memory to simply use a map instead by using `Object.create(null)`