### PR TITLE
Handle undefined list

### DIFF
--- a/js/nf9/nf9decode.js
+++ b/js/nf9/nf9decode.js
@@ -47,7 +47,8 @@ function nf9PktDecode(msg,rinfo) {
     function compileTemplate(list) {
         var i, z, nf, n;
         var f = "var o = Object.create(null); var t;\n";
-        for (i = 0, n = 0; i < list.length; i++, n += z.len) {
+        var listLen = list ? list.length : 0;
+        for (i = 0, n = 0; i < listLen; i++, n += z.len) {
             z = list[i];
             nf = nfTypes[z.type];
             if (!nf) {


### PR DESCRIPTION
This fixes a situation where the code throws an error like this:

```
node_modules/node-netflowv9/js/nf9/nf9decode.js:50
        for (i = 0, n = 0; i < list.length; i++, n += z.len) {
                                    ^
TypeError: Cannot read property 'length' of undefined
    at compileTemplate (node_modules/node-netflowv9/js/nf9/nf9decode.js:50:37)
    at decodeTemplate (node_modules/node-netflowv9/js/nf9/nf9decode.js:89:40)
    at NetFlowV9.nf9PktDecode (node_modules/node-netflowv9/js/nf9/nf9decode.js:171:32)
    at NetFlowV9.nfPktDecode (node_modules/node-netflowv9/netflowv9.js:33:25)
    at Immediate.NetFlowV9.fetch (node_modules/node-netflowv9/netflowv9.js:139:24)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```

This happened when I have a template object with a `len` property but no `compiled` or `list` property. Looking through the code I couldn't see where a template could get added without either of those, so I patched it by handling the `undefined` `list`.