### PR TITLE
Fix netflow decode to handle empty buffer lengths

### DIFF
--- a/js/nf9/nf9decode.js
+++ b/js/nf9/nf9decode.js
@@ -176,6 +176,9 @@ function nf9PktDecode(msg,rinfo) {
             debug('Unknown template/option data with flowset id %d for %s:%d',fsId,rinfo.address,rinfo.port);
         }
         buf = buf.slice(len);
+        if (len == 0) {
+            break;
+        }
     }
 
     return out;


### PR DESCRIPTION
Seeing an issue where a single bad packet with an empty buffer length (non empty buffer, with provided len of 0) will cause this process to just spin on that while loop. Best to at least have a way to exit when this happens